### PR TITLE
Allow SiTypeMappings to use lookahead types

### DIFF
--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/common/Math.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/common/Math.kt
@@ -1,0 +1,11 @@
+package jp.co.soramitsu.fearless_utils.common
+
+/**
+ * Complexity: O(n * log(n))
+ */
+fun List<Double>.median(): Double = sorted().let {
+    val middleRight = it[it.size / 2]
+    val middleLeft = it[(it.size - 1) / 2] // will be same as middleRight if list size is odd
+
+    (middleLeft + middleRight) / 2
+}


### PR DESCRIPTION
Currently there is a limitation of SiTypeMappings that does not allow them to access lookahead types (types declared later in metadata than the one that is currently processed). This does not allow FixedByteArray optimization to optimize AccountId32/20 for most of the chains requiring manual override in the json file. 
This PR resolves this issue by extracting SiTypeMappings into separate (second) parsing stage so they will override any type from standart parsing, if needed.

Tests are adjusted to reflect fixed behavior