### PR TITLE
Extrinsic builder/call bytes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.1.8'
+        versionName = '1.2.0'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/Type.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/Type.kt
@@ -30,7 +30,9 @@ class TypeReference(var value: Type<*>?) {
     private fun isInRecursion() = resolutionInProgress
 }
 
-abstract class Type<InstanceType>(val name: String) {
+typealias Type<I> = RuntimeType<I, I>
+
+abstract class RuntimeType<ENCODE, DECODE>(val name: String) {
 
     interface InstanceConstructor<I> {
 
@@ -42,7 +44,7 @@ abstract class Type<InstanceType>(val name: String) {
     /**
      * @throws EncodeDecodeException
      */
-    abstract fun decode(scaleCodecReader: ScaleCodecReader, runtime: RuntimeSnapshot): InstanceType
+    abstract fun decode(scaleCodecReader: ScaleCodecReader, runtime: RuntimeSnapshot): DECODE
 
     /**
      * @throws EncodeDecodeException
@@ -50,9 +52,12 @@ abstract class Type<InstanceType>(val name: String) {
     abstract fun encode(
         scaleCodecWriter: ScaleCodecWriter,
         runtime: RuntimeSnapshot,
-        value: InstanceType
+        value: ENCODE
     )
 
+    /**
+     * Checks whether [instance] is valid object to perform **encoding** using this type
+     */
     abstract fun isValidInstance(instance: Any?): Boolean
 
     /**
@@ -69,6 +74,6 @@ abstract class Type<InstanceType>(val name: String) {
             throw EncodeDecodeException(message)
         }
 
-        encode(scaleCodecWriter, runtime, value as InstanceType)
+        encode(scaleCodecWriter, runtime, value as ENCODE)
     }
 }

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/TypeExt.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/TypeExt.kt
@@ -13,18 +13,18 @@ import java.io.ByteArrayOutputStream
 /**
  * @throws CyclicAliasingException
  */
-fun Type<*>.skipAliases(): Type<*>? {
+fun RuntimeType<*, *>.skipAliases(): Type<*>? {
     if (this !is Alias) return this
 
     return aliasedReference.skipAliasesOrNull()?.value
 }
 
-fun Type<*>?.isFullyResolved() = this?.isFullyResolved ?: false
+fun RuntimeType<*, *>?.isFullyResolved() = this?.isFullyResolved ?: false
 
 /**
  * @throws EncodeDecodeException
  */
-fun <I> Type<I>.fromByteArray(runtime: RuntimeSnapshot, byteArray: ByteArray): I {
+fun <D> RuntimeType<*, D>.fromByteArray(runtime: RuntimeSnapshot, byteArray: ByteArray): D {
     val reader = ScaleCodecReader(byteArray)
 
     return ensureUnifiedException { decode(reader, runtime) }
@@ -33,22 +33,22 @@ fun <I> Type<I>.fromByteArray(runtime: RuntimeSnapshot, byteArray: ByteArray): I
 /**
  * @throws EncodeDecodeException
  */
-fun <I> Type<I>.fromHex(runtime: RuntimeSnapshot, hex: String): I {
+fun <D> RuntimeType<*, D>.fromHex(runtime: RuntimeSnapshot, hex: String): D {
     return ensureUnifiedException { fromByteArray(runtime, hex.fromHex()) }
 }
 
-fun <I> Type<I>.fromByteArrayOrNull(runtime: RuntimeSnapshot, byteArray: ByteArray): I? {
+fun <D> RuntimeType<*, D>.fromByteArrayOrNull(runtime: RuntimeSnapshot, byteArray: ByteArray): D? {
     return runCatching { fromByteArray(runtime, byteArray) }.getOrNull()
 }
 
-fun <I> Type<I>.fromHexOrNull(runtime: RuntimeSnapshot, hex: String): I? {
+fun <D> RuntimeType<*, D>.fromHexOrNull(runtime: RuntimeSnapshot, hex: String): D? {
     return runCatching { fromHex(runtime, hex) }.getOrNull()
 }
 
 /**
  * @throws EncodeDecodeException
  */
-fun <I> Type<I>.toByteArray(runtime: RuntimeSnapshot, value: I): ByteArray {
+fun <E> RuntimeType<E, *>.toByteArray(runtime: RuntimeSnapshot, value: E): ByteArray {
     return ensureUnifiedException {
         useScaleWriter { encode(this, runtime, value) }
     }
@@ -59,30 +59,30 @@ fun <I> Type<I>.toByteArray(runtime: RuntimeSnapshot, value: I): ByteArray {
  *
  * @throws EncodeDecodeException
  */
-fun Type<*>.bytes(runtime: RuntimeSnapshot, value: Any?): ByteArray {
+fun RuntimeType<*, *>.bytes(runtime: RuntimeSnapshot, value: Any?): ByteArray {
     return ensureUnifiedException {
         useScaleWriter { encodeUnsafe(this, runtime, value) }
     }
 }
 
-fun <I> Type<I>.toByteArrayOrNull(runtime: RuntimeSnapshot, value: I): ByteArray? {
+fun <E> RuntimeType<E, *>.toByteArrayOrNull(runtime: RuntimeSnapshot, value: E): ByteArray? {
     return runCatching { toByteArray(runtime, value) }.getOrNull()
 }
 
-fun Type<*>.bytesOrNull(runtime: RuntimeSnapshot, value: Any?): ByteArray? {
+fun RuntimeType<*, *>.bytesOrNull(runtime: RuntimeSnapshot, value: Any?): ByteArray? {
     return runCatching { bytes(runtime, value) }.getOrNull()
 }
 
 /**
  * @throws EncodeDecodeException
  */
-fun <I> Type<I>.toHex(runtime: RuntimeSnapshot, value: I) =
+fun <E> RuntimeType<E, *>.toHex(runtime: RuntimeSnapshot, value: E) =
     toByteArray(runtime, value).toHexString(withPrefix = true)
 
-fun Type<*>.toHexUntyped(runtime: RuntimeSnapshot, value: Any?) =
+fun RuntimeType<*, *>.toHexUntyped(runtime: RuntimeSnapshot, value: Any?) =
     bytes(runtime, value).toHexString(withPrefix = true)
 
-fun <I> Type<I>.toHexOrNull(runtime: RuntimeSnapshot, value: I) =
+fun <E> RuntimeType<E, *>.toHexOrNull(runtime: RuntimeSnapshot, value: E) =
     toByteArrayOrNull(runtime, value)?.toHexString(withPrefix = true)
 
 fun useScaleWriter(use: ScaleCodecWriter.() -> Unit): ByteArray {

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/Extrinsic.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/Extrinsic.kt
@@ -5,6 +5,7 @@ package jp.co.soramitsu.fearless_utils.runtime.definitions.types.generics
 import io.emeraldpay.polkaj.scale.ScaleCodecReader
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter
 import jp.co.soramitsu.fearless_utils.runtime.RuntimeSnapshot
+import jp.co.soramitsu.fearless_utils.runtime.definitions.types.RuntimeType
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.Type
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.bytes
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.errors.EncodeDecodeException
@@ -17,14 +18,22 @@ private val SIGNED_MASK = 0b1000_0000.toUByte()
 private const val TYPE_ADDRESS = "Address"
 private const val TYPE_SIGNATURE = "ExtrinsicSignature"
 
-object Extrinsic : Type<Extrinsic.Instance>("ExtrinsicsDecoder") {
+object Extrinsic :
+    RuntimeType<Extrinsic.EncodingInstance, Extrinsic.DecodedInstance>("ExtrinsicsDecoder") {
 
-    fun signatureType(runtime: RuntimeSnapshot): Type<*> {
-        return runtime.typeRegistry[TYPE_SIGNATURE]
-            ?: requiredTypeNotFound(TYPE_SIGNATURE)
+    class EncodingInstance(
+        val signature: Signature?,
+        val callRepresentation: CallRepresentation
+    ) {
+        sealed class CallRepresentation {
+
+            class Instance(val call: GenericCall.Instance) : CallRepresentation()
+
+            class Bytes(val bytes: ByteArray) : CallRepresentation()
+        }
     }
 
-    class Instance(
+    class DecodedInstance(
         val signature: Signature?,
         val call: GenericCall.Instance
     )
@@ -37,9 +46,17 @@ object Extrinsic : Type<Extrinsic.Instance>("ExtrinsicsDecoder") {
         companion object // for creator extensions
     }
 
+    fun signatureType(runtime: RuntimeSnapshot): Type<*> {
+        return runtime.typeRegistry[TYPE_SIGNATURE]
+            ?: requiredTypeNotFound(TYPE_SIGNATURE)
+    }
+
     override val isFullyResolved: Boolean = true
 
-    override fun decode(scaleCodecReader: ScaleCodecReader, runtime: RuntimeSnapshot): Instance {
+    override fun decode(
+        scaleCodecReader: ScaleCodecReader,
+        runtime: RuntimeSnapshot
+    ): DecodedInstance {
         val length = compactInt.read(scaleCodecReader)
 
         val extrinsicVersion = byte.read(scaleCodecReader).toUByte()
@@ -56,21 +73,37 @@ object Extrinsic : Type<Extrinsic.Instance>("ExtrinsicsDecoder") {
 
         val call = GenericCall.decode(scaleCodecReader, runtime)
 
-        return Instance(signature, call)
+        return DecodedInstance(signature, call)
     }
 
     override fun encode(
         scaleCodecWriter: ScaleCodecWriter,
         runtime: RuntimeSnapshot,
-        value: Instance
+        value: EncodingInstance
     ) {
-        val isSigned = value.signature != null
+        val callBytes = when (value.callRepresentation) {
+            is EncodingInstance.CallRepresentation.Instance ->
+                GenericCall.toByteArray(runtime, value.callRepresentation.call)
+
+            is EncodingInstance.CallRepresentation.Bytes -> value.callRepresentation.bytes
+        }
+
+        encodeCallBytes(scaleCodecWriter, runtime, value.signature, callBytes)
+    }
+
+    private fun encodeCallBytes(
+        scaleCodecWriter: ScaleCodecWriter,
+        runtime: RuntimeSnapshot,
+        signature: Signature?,
+        callBytes: ByteArray
+    ) {
+        val isSigned = signature != null
 
         val extrinsicVersion = runtime.metadata.extrinsic.version.toInt().toUByte()
         val encodedVersion = encodedVersion(extrinsicVersion, isSigned).toByte()
 
         val signatureWrapperBytes = if (isSigned) {
-            val signature = value.signature!!
+            requireNotNull(signature)
 
             val addressBytes = addressType(runtime).bytes(runtime, signature.accountIdentifier)
             val signatureBytes = signatureType(runtime).bytes(runtime, signature.signature)
@@ -81,15 +114,13 @@ object Extrinsic : Type<Extrinsic.Instance>("ExtrinsicsDecoder") {
             byteArrayOf()
         }
 
-        val callBytes = GenericCall.toByteArray(runtime, value.call)
-
         val extrinsicBodyBytes = byteArrayOf(encodedVersion) + signatureWrapperBytes + callBytes
 
         Bytes.encode(scaleCodecWriter, runtime, extrinsicBodyBytes)
     }
 
     override fun isValidInstance(instance: Any?): Boolean {
-        return instance is Instance
+        return instance is EncodingInstance
     }
 
     private fun encodedVersion(version: UByte, isSigned: Boolean): UByte {

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/Extrinsic.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/Extrinsic.kt
@@ -88,10 +88,10 @@ object Extrinsic :
             is EncodingInstance.CallRepresentation.Bytes -> value.callRepresentation.bytes
         }
 
-        encodeCallBytes(scaleCodecWriter, runtime, value.signature, callBytes)
+        encode(scaleCodecWriter, runtime, value.signature, callBytes)
     }
 
-    private fun encodeCallBytes(
+    private fun encode(
         scaleCodecWriter: ScaleCodecWriter,
         runtime: RuntimeSnapshot,
         signature: Signature?,

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/ExtrinsicExt.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/ExtrinsicExt.kt
@@ -38,3 +38,23 @@ fun multiAddressFromId(addressId: ByteArray): DictEnum.Entry<ByteArray> {
         value = addressId
     )
 }
+
+fun Extrinsic.EncodingInstance(
+    signature: Extrinsic.Signature?,
+    call: GenericCall.Instance
+): Extrinsic.EncodingInstance {
+    return Extrinsic.EncodingInstance(
+        signature,
+        Extrinsic.EncodingInstance.CallRepresentation.Instance(call)
+    )
+}
+
+fun Extrinsic.EncodingInstance(
+    signature: Extrinsic.Signature?,
+    callBytes: ByteArray
+): Extrinsic.EncodingInstance {
+    return Extrinsic.EncodingInstance(
+        signature,
+        Extrinsic.EncodingInstance.CallRepresentation.Bytes(callBytes)
+    )
+}

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/instances/AddressInstanceConstructor.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/instances/AddressInstanceConstructor.kt
@@ -3,14 +3,14 @@ package jp.co.soramitsu.fearless_utils.runtime.definitions.types.instances
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import jp.co.soramitsu.fearless_utils.runtime.definitions.registry.TypeRegistry
 import jp.co.soramitsu.fearless_utils.runtime.definitions.registry.getOrThrow
-import jp.co.soramitsu.fearless_utils.runtime.definitions.types.Type
+import jp.co.soramitsu.fearless_utils.runtime.definitions.types.RuntimeType
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.composite.DictEnum
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.generics.MULTI_ADDRESS_ID
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.primitives.FixedByteArray
 
 private const val ADDRESS_TYPE = "Address"
 
-object AddressInstanceConstructor : Type.InstanceConstructor<AccountId> {
+object AddressInstanceConstructor : RuntimeType.InstanceConstructor<AccountId> {
 
     override fun constructInstance(typeRegistry: TypeRegistry, value: AccountId): Any {
         return when (val addressType = typeRegistry.getOrThrow(ADDRESS_TYPE)) {

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/instances/SignatureInstanceConstructor.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/instances/SignatureInstanceConstructor.kt
@@ -4,7 +4,7 @@ import jp.co.soramitsu.fearless_utils.encrypt.SignatureWrapper
 import jp.co.soramitsu.fearless_utils.encrypt.vByte
 import jp.co.soramitsu.fearless_utils.runtime.definitions.registry.TypeRegistry
 import jp.co.soramitsu.fearless_utils.runtime.definitions.registry.getOrThrow
-import jp.co.soramitsu.fearless_utils.runtime.definitions.types.Type
+import jp.co.soramitsu.fearless_utils.runtime.definitions.types.RuntimeType
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.composite.DictEnum
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.composite.Struct
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.generics.MultiSignature
@@ -12,7 +12,7 @@ import jp.co.soramitsu.fearless_utils.runtime.definitions.types.generics.prepare
 
 private const val EXTRINSIC_SIGNATURE_TYPE = "ExtrinsicSignature"
 
-object SignatureInstanceConstructor : Type.InstanceConstructor<SignatureWrapper> {
+object SignatureInstanceConstructor : RuntimeType.InstanceConstructor<SignatureWrapper> {
 
     override fun constructInstance(typeRegistry: TypeRegistry, value: SignatureWrapper): Any {
         return when (val type = typeRegistry.getOrThrow(EXTRINSIC_SIGNATURE_TYPE)) {

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/ExtrinsicTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/ExtrinsicTest.kt
@@ -6,6 +6,7 @@ import jp.co.soramitsu.fearless_utils.extensions.toHexString
 import jp.co.soramitsu.fearless_utils.runtime.RealRuntimeProvider
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.composite.DictEnum
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.fromHex
+import jp.co.soramitsu.fearless_utils.runtime.definitions.types.generics.Extrinsic.EncodingInstance.*
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.instances.AddressInstanceConstructor
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.instances.SignatureInstanceConstructor
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.toHex
@@ -72,7 +73,7 @@ class ExtrinsicTest {
             value = SignatureWrapper.Sr25519(signatureInHex.fromHex())
         )
 
-        val extrinsic = Extrinsic.Instance(
+        val extrinsic = Extrinsic.EncodingInstance(
             signature = Extrinsic.Signature.new(
                 accountIdentifier = AddressInstanceConstructor.constructInstance(
                     typeRegistry = runtime.typeRegistry,


### PR DESCRIPTION
# Changes

* Generalize Type to allow diffrent type parameters for encoding and decoding (`RuntimeType<E, D>`)
* Implement different encoding and decoding for `Extrinsic` to allow Variant (Call or Bytes) for encoding and leave Call for decoding
* Use Extrinsic variant encoding in ExtrinsicBuilder to allow building extrinsic/signature both with call instances and call bytes

# Incomatibilites
*  Extrinsic.Instance is splitted to `Extrinisc.EncdoingInstance` and `Extrinsic.DecodingInstance`
* Despite typealiasing `RuntimeType<I, I>` to `Type<I>` to preserve compatibility with current version, `Type.InstanceConstructor `usages should be renamed to `RuntimeType.InstanceConstructor`