### PR TITLE
Runtime/storage key splitting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.3.2'
+        versionName = '1.3.3'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
@@ -136,7 +136,7 @@ fun StorageEntry.splitKey(runtime: RuntimeSnapshot, fullKey: String): List<Any?>
     scaleReader.skip(CALL_HASH_LENGTH)
 
     return entryType.keys.zip(entryType.hashers).mapIndexed { index, (key, hasher) ->
-        val hashSize = when(hasher) {
+        val hashSize = when (hasher) {
             StorageHasher.Blake2_128Concat -> 16
             StorageHasher.Twox64Concat -> 8
             StorageHasher.Identity -> 0

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
@@ -123,6 +123,11 @@ fun StorageEntry.storageKey(runtime: RuntimeSnapshot, vararg keys: Any?): String
 private const val MODULE_HASH_LENGTH = 16
 private const val CALL_HASH_LENGTH = MODULE_HASH_LENGTH
 
+/**
+ * Splits scale-encoded full storage key into its components (arguments)
+ * @throws IllegalStateException - in case of non-concat hasher or unknown type for some argument
+ * @throws IllegalArgumentException - in case storage has plain type
+ */
 // layout: <moduleHash><callHash><key1Hash><key1? if concat>...<keyNHash><keyN? if concat>
 fun StorageEntry.splitKey(runtime: RuntimeSnapshot, fullKey: String): List<Any?> {
     val scaleReader = ScaleCodecReader(fullKey.fromHex())


### PR DESCRIPTION
Add method to storage entry which auto-splits scale storage key into arguments. It is needed for convenient prefix key enumeration