### PR TITLE
Runtime/optimize storage keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.3.3'
+        versionName = '1.3.4'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
@@ -69,8 +69,8 @@ fun Module.eventOrNull(name: String): Event? = events?.get(name)
 /**
  * Unified representation of [StorageEntryType] argument types
  */
-val StorageEntry.keys : List<RuntimeType<*, *>?>
-    get() = when(type) {
+val StorageEntry.keys: List<RuntimeType<*, *>?>
+    get() = when (type) {
         is StorageEntryType.Plain -> emptyList()
         is StorageEntryType.NMap -> type.keys
     }
@@ -78,8 +78,8 @@ val StorageEntry.keys : List<RuntimeType<*, *>?>
 /**
  * Unified representation of [StorageEntryType] hashers
  */
-val StorageEntry.hashers : List<StorageHasher>
-    get() = when(type) {
+val StorageEntry.hashers: List<StorageHasher>
+    get() = when (type) {
         is StorageEntryType.Plain -> emptyList()
         is StorageEntryType.NMap -> type.hashers
     }

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExt.kt
@@ -5,6 +5,8 @@ import jp.co.soramitsu.fearless_utils.extensions.fromHex
 import jp.co.soramitsu.fearless_utils.extensions.toHexString
 import jp.co.soramitsu.fearless_utils.hash.Hasher.xxHash128
 import jp.co.soramitsu.fearless_utils.runtime.RuntimeSnapshot
+import jp.co.soramitsu.fearless_utils.runtime.definitions.types.RuntimeType
+import jp.co.soramitsu.fearless_utils.runtime.definitions.types.Type
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.bytes
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.errors.EncodeDecodeException
 import jp.co.soramitsu.fearless_utils.runtime.metadata.module.Event
@@ -66,6 +68,24 @@ fun Module.event(name: String): Event = eventOrNull(name) ?: throw NoSuchElement
 fun Module.eventOrNull(name: String): Event? = events?.get(name)
 
 /**
+ * Unified representation of [StorageEntryType] argument types
+ */
+val StorageEntry.keys : List<RuntimeType<*, *>?>
+    get() = when(type) {
+        is StorageEntryType.Plain -> emptyList()
+        is StorageEntryType.NMap -> type.keys
+    }
+
+/**
+ * Unified representation of [StorageEntryType] hashers
+ */
+val StorageEntry.hashers : List<StorageHasher>
+    get() = when(type) {
+        is StorageEntryType.Plain -> emptyList()
+        is StorageEntryType.NMap -> type.hashers
+    }
+
+/**
  * Constructs a key for storage with no arguments.
  * This either fill be a full key for [StorageEntryType.Plain] entries,
  * or a prefix key for [StorageEntryType.Map] and [StorageEntryType.DoubleMap] entries
@@ -95,9 +115,9 @@ fun StorageEntryType.dimension() = when (this) {
  * @throws IllegalStateException if some of types used for encoding cannot be resolved
  * @throws EncodeDecodeException if error happened during encoding
  */
-fun StorageEntry.storageKey(runtime: RuntimeSnapshot, vararg keys: Any?): String {
+fun StorageEntry.storageKey(runtime: RuntimeSnapshot, vararg arguments: Any?): String {
     // keys size can be less then dimension to retrieve by prefix
-    if (keys.size > type.dimension()) wrongEntryType()
+    if (arguments.size > type.dimension()) wrongEntryType()
 
     val keysWithHashers = when (type) {
         is StorageEntryType.Plain -> emptyList()
@@ -109,7 +129,7 @@ fun StorageEntry.storageKey(runtime: RuntimeSnapshot, vararg keys: Any?): String
     keyOutputStream.write(moduleHash())
     keyOutputStream.write(serviceHash())
 
-    keys.forEachIndexed { index, key ->
+    arguments.forEachIndexed { index, key ->
         val (keyType, keyHasher) = keysWithHashers[index]
 
         val keyEncoded = keyType?.bytes(runtime, key) ?: typeNotResolved(fullName)
@@ -118,6 +138,42 @@ fun StorageEntry.storageKey(runtime: RuntimeSnapshot, vararg keys: Any?): String
     }
 
     return keyOutputStream.toByteArray().toHexString(withPrefix = true)
+}
+
+/**
+ * Constructs multiple keys for storage with supplied arguments.
+ * This method cannot be used to construct prefix keys, for prefix construction see [StorageEntry.storageKey]
+ *
+ * @throws IllegalArgumentException if the number of arguments is not equal to [StorageEntryType.dimension]
+ * @throws IllegalStateException if some of types used for encoding cannot be resolved
+ * @throws EncodeDecodeException if error happened during encoding
+ */
+fun StorageEntry.storageKeys(runtime: RuntimeSnapshot, keysArguments: List<List<Any?>>): List<String> {
+    val argumentsTypes = this.keys
+    val argumentsHashers = this.hashers
+
+    val moduleHash = moduleHash()
+    val storageHash = serviceHash()
+
+    return keysArguments.map { arguments ->
+        if (arguments.size != type.dimension()) wrongEntryType()
+
+        val keyOutputStream = ByteArrayOutputStream()
+
+        keyOutputStream.write(moduleHash)
+        keyOutputStream.write(storageHash)
+
+        arguments.forEachIndexed { index, key ->
+            val keyType = argumentsTypes[index]
+            val keyHasher = argumentsHashers[index]
+
+            val keyEncoded = keyType?.bytes(runtime, key) ?: typeNotResolved(fullName)
+
+            keyOutputStream.write(keyHasher.hashingFunction(keyEncoded))
+        }
+
+        keyOutputStream.toByteArray().toHexString(withPrefix = true)
+    }
 }
 
 private const val MODULE_HASH_LENGTH = 16

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExtKtTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExtKtTest.kt
@@ -75,7 +75,6 @@ class RuntimeMetadataExtKtTest {
                 hashers = listOf(
                     StorageHasher.Identity,
                     StorageHasher.Identity,
-                    StorageHasher.Identity
                 )
             )
         )

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExtKtTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataExtKtTest.kt
@@ -67,6 +67,48 @@ class RuntimeMetadataExtKtTest {
     }
 
     @Test
+    fun `test storageKeys()`() {
+        val storageEntry = storageEntry(
+            StorageEntryType.NMap(
+                value = BooleanType,
+                keys = listOf(BooleanType, BooleanType),
+                hashers = listOf(
+                    StorageHasher.Identity,
+                    StorageHasher.Identity,
+                    StorageHasher.Identity
+                )
+            )
+        )
+
+        val arguments = listOf(
+            listOf(false, false),
+            listOf(false, true),
+            listOf(true, false),
+            listOf(true, true),
+        )
+
+        val expectedKeys = listOf(
+            PREFIX + "0000",
+            PREFIX + "0001",
+            PREFIX + "0100",
+            PREFIX + "0101",
+        )
+
+        val storageKeys = storageEntry.storageKeys(runtime, arguments)
+
+        expectedKeys.zip(storageKeys).forEach { (expected, actual) ->
+            assertEquals(expected, actual)
+        }
+
+        // should check dimensionality
+        assertThrows<IllegalArgumentException> {
+            storageEntry.storageKeys(runtime, listOf(emptyList()))
+            storageEntry.storageKeys(runtime, listOf(listOf(true)))
+            storageEntry.storageKeys(runtime, listOf(listOf(true, true, true)))
+        }
+    }
+
+    @Test
     fun `should split keys`() {
         val storageEntry = storageEntry(
             StorageEntryType.NMap(


### PR DESCRIPTION
Optimized method to construct multiple storage keys of the same type
Remove unnecessary list allocation caused by zip()
