### PR TITLE
Fix/infura batches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.7.2'
+        versionName = '1.7.3'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/SocketService.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/SocketService.kt
@@ -358,13 +358,17 @@ class SocketService(
 
     private class AccumulatingBatchRequest(
         private val allDoneCallBack: ResponseListener<List<RpcResponse>>,
-        expectedSize: Int
+        private val batchSize: Int
     ) : ResponseListener<RpcResponse> {
 
-        private var arrivedResponses: MutableList<RpcResponse> = ArrayList(expectedSize)
+        private var arrivedResponses: MutableList<RpcResponse> = ArrayList(batchSize)
 
         override fun onNext(response: RpcResponse) {
             arrivedResponses.add(response)
+
+            if (arrivedResponses.size == batchSize) {
+                allDoneCallBack.onNext(arrivedResponses)
+            }
         }
 
         override fun onError(throwable: Throwable) {

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/request/SingleSendable.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/request/SingleSendable.kt
@@ -15,6 +15,7 @@ internal class SingleSendable(
     override val numberOfNeededResponses: Int = 1
 
     override fun relatesTo(id: Int): Boolean = request.id == id
+
     override fun sendTo(rpcSocket: RpcSocket) {
         rpcSocket.sendRpcRequest(request)
     }
@@ -33,7 +34,9 @@ internal class BatchSendable(
     override val numberOfNeededResponses: Int = requests.size
 
     private val ids = requests.mapTo(mutableSetOf(), RpcRequest::id)
+
     override fun relatesTo(id: Int): Boolean = id in ids
+
     override fun sendTo(rpcSocket: RpcSocket) {
         rpcSocket.sendBatchRpcRequests(requests)
     }

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/request/SingleSendable.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/request/SingleSendable.kt
@@ -11,6 +11,9 @@ internal class SingleSendable(
     override val deliveryType: DeliveryType,
     override val callback: SocketService.ResponseListener<RpcResponse>
 ) : SocketStateMachine.Sendable {
+
+    override val numberOfNeededResponses: Int = 1
+
     override fun relatesTo(id: Int): Boolean = request.id == id
     override fun sendTo(rpcSocket: RpcSocket) {
         rpcSocket.sendRpcRequest(request)
@@ -26,6 +29,8 @@ internal class BatchSendable(
     override val deliveryType: DeliveryType,
     override val callback: SocketService.ResponseListener<RpcResponse>
 ) : SocketStateMachine.Sendable {
+
+    override val numberOfNeededResponses: Int = requests.size
 
     private val ids = requests.mapTo(mutableSetOf(), RpcRequest::id)
     override fun relatesTo(id: Int): Boolean = id in ids

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/state/SocketStateMachine.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/state/SocketStateMachine.kt
@@ -1,7 +1,6 @@
 package jp.co.soramitsu.fearless_utils.wsrpc.state
 
 import jp.co.soramitsu.fearless_utils.wsrpc.SocketService
-import jp.co.soramitsu.fearless_utils.wsrpc.request.BatchSendable
 import jp.co.soramitsu.fearless_utils.wsrpc.request.DeliveryType
 import jp.co.soramitsu.fearless_utils.wsrpc.response.RpcResponse
 import jp.co.soramitsu.fearless_utils.wsrpc.socket.RpcSocket

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/state/SocketStateMachine.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/state/SocketStateMachine.kt
@@ -443,8 +443,6 @@ object SocketStateMachine {
 
     private fun Map<Sendable, ResponseCounter>.add(sendable: Sendable) = plus(sendable to 0)
 
-    private fun Set<Sendable>.withCounter() = associateWith { 0 }
-
     private fun getRequestsToResendAndReportErrorToOthers(
         state: State.Connected,
         mutableSideEffects: MutableList<SideEffect>,
@@ -492,3 +490,5 @@ object SocketStateMachine {
             it.deliveryType == deliveryType
         }
 }
+
+internal fun Set<SocketStateMachine.Sendable>.withCounter() = associateWith { 0 }

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/state/SocketStateMachine.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/wsrpc/state/SocketStateMachine.kt
@@ -441,7 +441,6 @@ object SocketStateMachine {
         }
     }
 
-
     private fun Map<Sendable, ResponseCounter>.add(sendable: Sendable) = plus(sendable to 0)
 
     private fun Set<Sendable>.withCounter() = associateWith { 0 }


### PR DESCRIPTION
Infura nodes does not group batch responses the same way request was grouped. They can group requests in batches whatever they think is more efficient

Cases:

Sending: batch([1])
Response: single(1)

---

Sending: batch(1, 2)
Sending: single(3)
Response: batch(1, 3)
Response: single(2)
