### PR TITLE
Fix native lib crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '2.0.0'
+        versionName = '2.0.1'
         versionCode = 1
 
         // SDK and tools

--- a/sr25519-java/Cargo.toml
+++ b/sr25519-java/Cargo.toml
@@ -13,7 +13,6 @@ schnorrkel = { version="<=0.9.1" }
 
 [profile.release]
 lto = true
-opt-level = "s"
 
 [lib]
 name = "sr25519java"

--- a/substrate-sdk-android/build.gradle
+++ b/substrate-sdk-android/build.gradle
@@ -58,7 +58,6 @@ cargo {
     module = "../sr25519-java/"
     libname = "sr25519java"
     targets = ["arm", "arm64", "x86", "x86_64"]
-    profile = "release"
 }
 
 tasks.whenTaskAdded { task ->


### PR DESCRIPTION
After #78 certain devices starts to crash with

```
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "dl_iterate_phdr" referenced by "/data/app/~~O7xZcBb6BHAK6IbkBUz5lQ==/io.novasama.polkadotapp-UcKdIUU05U6-9-Ae_JZbjw==/base.apk!/lib/arm64-v8a/libsr25519java.so"
```

Upon investigation, it turned out that PR changed rust compile mode to `release` to optimize `so` file size. After rewerting this change, the crash stopped happening for me. So reverting `release` mode for now untill futher investigation