### PR TITLE
Fix/stack overflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '2.2.0'
+        versionName = '2.2.1'
         versionCode = 1
 
         // SDK and tools

--- a/substrate-sdk-android/src/test/java/io/novasama/substrate_sdk_android/runtime/extrinsic/ExtrinsicBuilderTest.kt
+++ b/substrate-sdk-android/src/test/java/io/novasama/substrate_sdk_android/runtime/extrinsic/ExtrinsicBuilderTest.kt
@@ -240,6 +240,20 @@ class ExtrinsicBuilderTest {
             .buildExtrinsic()
     }
 
+    @Test
+    fun `should not allow to add call to itself`() = runBlockingTest {
+        val extrinsicBuilder = createExtrinsicBuilder()
+        repeat(2) {
+            extrinsicBuilder.testSingleTransfer()
+        }
+
+        val call = extrinsicBuilder.getWrappedCall()
+        extrinsicBuilder.call(call)
+
+        // This will fail with StackOverflow is call was added to itself
+        extrinsicBuilder.buildExtrinsic()
+    }
+
     private fun createExtrinsicBuilder(usedRuntime: RuntimeSnapshot = runtime) = ExtrinsicBuilder(
         runtime = usedRuntime,
         signer = keypairSigner(),


### PR DESCRIPTION
Sequence of steps to reproduce:

1. Add 2 calls to extrinsics
2. Retrive call via getCall() - ExtrinsicBuilder returns batch
3. Add returned batch back to extrinsic builder

Since batch parameter contains the same list that is later modified to add this batch back, batch ended up being added to itself
To solve this, we should always return a new copy of call list when using `getWrappedCall()` and `getCalls()` 