### PR TITLE
Hotfix: Scale plugin - Backport to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '2.6.0'
+        versionName = '2.6.1'
         versionCode = 1
 
         // SDK and tools

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/EnumDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/EnumDecoder.kt
@@ -1,23 +1,8 @@
-@file:OptIn(ExperimentalSerializationApi::class)
-
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decoder
 
-import io.novasama.substrate_sdk_android.koltinx_serialization_scale.utils.shouldUseTransientStructInEnum
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.modules.SerializersModule
 
 class EnumDecoder(
     serializersModule: SerializersModule,
     value: Any?
-) : PrimitiveDecoder(serializersModule, value) {
-
-    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
-        if (descriptor.shouldUseTransientStructInEnum()) {
-            return TransientStructDecoder(serializersModule, singleField = value)
-        }
-
-        return super.beginStructure(descriptor)
-    }
-}
+) : PrimitiveDecoder(serializersModule, value)

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/StructDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/StructDecoder.kt
@@ -18,8 +18,17 @@ class StructDecoder(
     private var currentIndex = 0
 
     override fun decodeIdentity(descriptor: SerialDescriptor, index: Int): Any? {
-        val key = descriptor.getElementName(index).camelCaseToSnakeCase()
-        return value[key]
+        val key = descriptor.getElementName(index)
+
+        if (key in value) return value[key]
+
+        // TODO this is a temp solution to cater both camel and snake cases in struct fields
+        // This should be addressed better to introducing some annotation to specify field naming strategy per entire struct
+        // Also we should check the underlying layer to find out why some fields are not transformed to camel case
+        val snakeCaseKey = key.camelCaseToSnakeCase()
+        if (snakeCaseKey in value) return value[snakeCaseKey]
+
+        error("Key '$key' (or '${snakeCaseKey}') is not found in the $value")
     }
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/EnumEncoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/EnumEncoder.kt
@@ -1,9 +1,6 @@
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.encoder
 
-import io.novasama.substrate_sdk_android.koltinx_serialization_scale.utils.shouldUseTransientStructInEnum
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.modules.SerializersModule
 
 class EnumEncoder(
@@ -14,13 +11,5 @@ class EnumEncoder(
 
     override fun encodeIdentity(value: Any?) {
         nodeConsumer(DictEnum.Entry(variantName, value))
-    }
-
-    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
-        if (descriptor.shouldUseTransientStructInEnum()) {
-            return TransientStructEncoder(serializersModule, nodeConsumer = ::encodeIdentity)
-        }
-
-        return super.beginStructure(descriptor)
     }
 }

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/StructEncoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/StructEncoder.kt
@@ -20,8 +20,13 @@ class StructEncoder(
     private var current = mutableMapOf<String, Any?>()
 
     override fun encodeIdentity(descriptor: SerialDescriptor, index: Int, value: Any?) {
-        val tag = descriptor.getElementName(index).camelCaseToSnakeCase()
+        val tag = descriptor.getElementName(index)
+
+        // TODO this is a temp solution to cater both camel and snake cases in struct fields
+        // This should be addressed better to introducing some annotation to specify field naming strategy per entire struct
+        // Also we should check the underlying layer to find out why some fields are not transformed to camel case
         current[tag] = value
+        current[tag.camelCaseToSnakeCase()] = value
     }
 
     override fun getEncodedValue(): Struct.Instance {

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/DictEnumTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/DictEnumTest.kt
@@ -1,6 +1,7 @@
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
 
 import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.SerializedFallback
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.TransientStruct
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
 import kotlinx.serialization.SerialName
@@ -22,6 +23,10 @@ sealed class Sealed {
 
     @Serializable
     data class SingleList(val elements: List<Boolean>) : Sealed()
+
+    @Serializable
+    @TransientStruct
+    data class SingleTransient(val element: Boolean) : Sealed()
 
     @Serializable
     @SerialName("ChangedName")
@@ -48,13 +53,19 @@ class EnumTest : DecodeTest() {
     @Test
     fun `should decode variant value`() = runDecodeTest(
         expected = Sealed.Single(true) as Sealed,
-        raw = DictEnum.Entry("Single", true)
+        raw = DictEnum.Entry("Single", Struct.Instance(mapOf("element" to true)))
     )
 
     @Test
     fun `should decode variant value list`() = runDecodeTest(
         expected = Sealed.SingleList(listOf(true, false)) as Sealed,
-        raw = DictEnum.Entry("SingleList", listOf(true, false))
+        raw = DictEnum.Entry("SingleList",  Struct.Instance(mapOf("elements" to listOf(true, false))))
+    )
+
+    @Test
+    fun `should decode transient struct value`() = runDecodeTest(
+        expected = Sealed.SingleTransient(true) as Sealed,
+        raw = DictEnum.Entry("SingleTransient", true)
     )
 
     @Test

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/StructTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/StructTest.kt
@@ -5,6 +5,7 @@ import io.novasama.substrate_sdk_android.koltinx_serialization_scale.serializers
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.junit.Assert
 import org.junit.Test
 import java.math.BigInteger
 
@@ -88,6 +89,11 @@ class StructTest : DecodeTest() {
 
         runDecodeTest(
             raw = Struct.Instance(mapOf("some_name" to true)),
+            expected = A(someName = true)
+        )
+
+        runDecodeTest(
+            raw = Struct.Instance(mapOf("someName" to true)),
             expected = A(someName = true)
         )
     }

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/DictEnumTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/DictEnumTest.kt
@@ -1,5 +1,6 @@
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.encode
 
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.TransientStruct
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
 import kotlinx.serialization.SerialName
@@ -20,6 +21,11 @@ sealed class Sealed {
 
     @Serializable
     class SingleList(val elements: List<Boolean>) : Sealed()
+
+    @Serializable
+    @TransientStruct
+    class SingleTransient(val element: Boolean) : Sealed()
+
 
     @Serializable
     @SerialName("ChangedName")
@@ -43,13 +49,19 @@ class EnumTests : EncodeTest() {
     @Test
     fun `should encode variant with single value`() = runEncodeTest(
         value = Sealed.Single(false) as Sealed,
-        expected = DictEnum.Entry("Single", false)
+        expected = DictEnum.Entry("Single", Struct.Instance(mapOf("element" to false)))
+    )
+
+    @Test
+    fun `should encode variant with single transient value`() = runEncodeTest(
+        value = Sealed.SingleTransient(false) as Sealed,
+        expected = DictEnum.Entry("SingleTransient", false)
     )
 
     @Test
     fun `should encode variant value list`() = runEncodeTest(
         value = Sealed.SingleList(listOf(true, false)) as Sealed,
-        expected = DictEnum.Entry("SingleList", listOf(true, false))
+        expected = DictEnum.Entry("SingleList", Struct.Instance(mapOf("elements" to listOf(true, false))))
     )
 
     @Test

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/StructTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/StructTest.kt
@@ -101,11 +101,11 @@ class StructTest : EncodeTest() {
     fun `should encode camel case as snake case`() {
 
         @Serializable
-        data class A(@SerialName("b") val a: Boolean)
+        data class A(val aB: Boolean)
 
         runEncodeTest(
-            expected = Struct.Instance(mapOf("b" to true)),
-            value = A(a = true)
+            expected = Struct.Instance(mapOf("aB" to true, "a_b" to true)),
+            value = A(aB = true)
         )
     }
 


### PR DESCRIPTION
* Structs can encode/decode both camel and snake case (approach should be revisited)
* Remove implicit enforced transient struct for single-field enum variants
* Better error message when struct field is not found during decoding