### PR TITLE
Feature/raw scale encoding

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@
 
 * Support for raw scale serialization
 * Support for encoding regular enums to DictEnum.Entry with null associated value
+* Improve error messages for enum decoding
 
 ### Changes
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,13 +2,20 @@
 
 ## v2.9.2
 
-Support for raw scale serialization
+* Support for raw scale serialization
+* Support for encoding regular enums to DictEnum.Entry with null associated value
 
 ### Changes
+
+#### Raw scale serialization
 
 * Useful when we want to operate low level scale structures for some of the fields / arguments
 * `RawScaleValue` can be used for fields
 * `AsRawScaleValue` wrapper can be used for top-level serialization (e.g. storage keys / whole values)
+
+#### Regular enum encoding to DictEnum.Entry with null associated value
+
+* Introduced`AsDictEnum` annotation that can be applied to `enum class` to signal that it should be encoded as `DictEnum.Entry`
 
 ## v2.9.1
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,11 +4,15 @@
 
 Support for raw scale serialization
 
-* Usefully when we want to operate low level scale structures for some of the fields / arguments
+### Changes
+
+* Useful when we want to operate low level scale structures for some of the fields / arguments
 * `RawScaleValue` can be used for fields
 * `AsRawScaleValue` wrapper can be used for top-level serialization (e.g. storage keys / whole values)
 
 ## v2.9.1
+
+### Changes
 
 * Automatically convert between snake and camel case for struct fields
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.9.2
+
+Support for raw scale serialization
+
+* Usefully when we want to operate low level scale structures for some of the fields / arguments
+* `RawScaleValue` can be used for fields
+* `AsRawScaleValue` wrapper can be used for top-level serialization (e.g. storage keys / whole values)
+
+## v2.9.1
+
+* Automatically convert between snake and camel case for struct fields
+
 ## v2.9.0
 
 This release is focused around fixes and refactoring of import from json feature

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '2.9.1'
+        versionName = '2.9.2'
         versionCode = 1
 
         // SDK and tools

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/annotations/AsDictEnum.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/annotations/AsDictEnum.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialInfo
 
 /**
- * Instruct serializer to encode given regular enum as dict enum
+ * Instruct serializer to encode given regular enum as dict enum entry with null associated value
  *
  * Example:
  * ```

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/annotations/AsDictEnum.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/annotations/AsDictEnum.kt
@@ -8,14 +8,16 @@ import kotlinx.serialization.SerialInfo
  *
  * Example:
  * ```
- * @AsDictEnum
  * @Serializable
- * data enum AsDictEnum(val field1: Boolean, val field2: Boolean)
+ * @AsDictEnum
+ * enum class TestEnumDict {
+ *     A, B
+ * }
  *
- * val decoded = AsTupleStruct(true, false)
- * val encoded = listOf(true, false)
+ * val decoded = TestEnumDict.A
+ * val encoded = DictEnum.Entry("A", null)
  *
- * assert(decoded == Scale.decode<AsTupleStruct>(encoded))
+ * assert(decoded == Scale.decode<TestEnumDict>(encoded))
  * assert(encoded == Scale.encode(decoded))
  * ```
  **/

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/annotations/AsDictEnum.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/annotations/AsDictEnum.kt
@@ -1,0 +1,25 @@
+package io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Instruct serializer to encode given regular enum as dict enum
+ *
+ * Example:
+ * ```
+ * @AsDictEnum
+ * @Serializable
+ * data enum AsDictEnum(val field1: Boolean, val field2: Boolean)
+ *
+ * val decoded = AsTupleStruct(true, false)
+ * val encoded = listOf(true, false)
+ *
+ * assert(decoded == Scale.decode<AsTupleStruct>(encoded))
+ * assert(encoded == Scale.encode(decoded))
+ * ```
+ **/
+@OptIn(ExperimentalSerializationApi::class)
+@Target(AnnotationTarget.CLASS)
+@SerialInfo
+annotation class AsDictEnum

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/EnumDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/EnumDecoder.kt
@@ -1,8 +1,0 @@
-package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decoder
-
-import kotlinx.serialization.modules.SerializersModule
-
-class EnumDecoder(
-    serializersModule: SerializersModule,
-    value: Any?
-) : PrimitiveDecoder(serializersModule, value)

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/PrimitiveDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/PrimitiveDecoder.kt
@@ -26,6 +26,10 @@ open class PrimitiveDecoder(
     val value: Any?
 ) : ScaleDecoder {
 
+    override fun decodeRaw(): Any? {
+        return value
+    }
+
     override fun decodeByteArray(): ByteArray {
         return decodeCasted()
     }

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/PrimitiveDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/PrimitiveDecoder.kt
@@ -57,12 +57,22 @@ open class PrimitiveDecoder(
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
         val name = detectEnumEntryName()
-        val index = enumDescriptor.getElementIndex(name)
+        var index = enumDescriptor.getElementIndex(name)
 
         if (index != UNKNOWN_NAME) return index
 
-        val fallback = enumDescriptor.findSerializedFallback() ?: return index
-        return enumDescriptor.getElementIndex(fallback)
+        val fallback = enumDescriptor.findSerializedFallback()
+        if (fallback == null) {
+            error("Enum entry $name not found in ${enumDescriptor.serialName}")
+        }
+
+        index = enumDescriptor.getElementIndex(fallback)
+
+        if (index != UNKNOWN_NAME) {
+            return index
+        } else {
+            error("Fallback enum entry $fallback not found in ${enumDescriptor.serialName}")
+        }
     }
 
     private fun detectEnumEntryName(): String {

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/PrimitiveDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/PrimitiveDecoder.kt
@@ -56,13 +56,27 @@ open class PrimitiveDecoder(
     override fun decodeDouble(): Double = unsupportedDecoding("Char")
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
-        val name = decodeString()
+        val name = detectEnumEntryName()
         val index = enumDescriptor.getElementIndex(name)
 
         if (index != UNKNOWN_NAME) return index
 
         val fallback = enumDescriptor.findSerializedFallback() ?: return index
         return enumDescriptor.getElementIndex(fallback)
+    }
+
+    private fun detectEnumEntryName(): String {
+        return when(value) {
+            is String -> value
+            is DictEnum.Entry<*> -> {
+                require(value.value == null) {
+                    "Regular enum cannot be decoded with present associated value: $value"
+                }
+
+                value.name
+            }
+            else -> error("Cannot extract enum entry name from: $value")
+        }
     }
 
     override fun decodeFloat(): Float = unsupportedDecoding("Float")
@@ -131,7 +145,7 @@ open class PrimitiveDecoder(
                 ?: serializer.findFallbackFromAnnotations()
                 ?: error("Subtype $variantClassName not registered")
 
-        val enumDecoder = EnumDecoder(serializersModule, enumEntry.value)
+        val enumDecoder = PrimitiveDecoder(serializersModule, enumEntry.value)
         return actualSerializer.deserialize(enumDecoder) as T
     }
 

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/ScaleDecoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decoder/ScaleDecoder.kt
@@ -5,6 +5,8 @@ import java.math.BigInteger
 
 interface ScaleDecoder : Decoder {
 
+    fun decodeRaw(): Any?
+
     fun decodeByteArray(): ByteArray
 
     fun decodeNumber(): BigInteger

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/BaseEncoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/BaseEncoder.kt
@@ -2,9 +2,11 @@
 
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.encoder
 
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.AsDictEnum
 import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.AsTuple
 import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.TransientStruct
 import io.novasama.substrate_sdk_android.koltinx_serialization_scale.utils.isAnnotatedWith
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationStrategy
@@ -50,7 +52,13 @@ abstract class BaseEncoder : ScaleEncoder {
     override fun encodeDouble(value: Double) = unsupportedEncoding("Double")
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
-        encodeIdentity(enumDescriptor.getElementName(index))
+        val elementName = enumDescriptor.getElementName(index)
+
+        if (enumDescriptor.isAnnotatedWith<AsDictEnum>()) {
+            encodeIdentity(DictEnum.Entry(elementName, null))
+        } else {
+            encodeIdentity(elementName)
+        }
     }
 
     override fun encodeFloat(value: Float) = unsupportedEncoding("Float")

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/BaseEncoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/BaseEncoder.kt
@@ -37,6 +37,8 @@ abstract class BaseEncoder : ScaleEncoder {
         }
     }
 
+    override fun encodeRaw(value: Any?) = encodeIdentity(value)
+
     override fun encodeNumber(number: BigInteger) = encodeIdentity(number)
 
     override fun encodeByteArray(bytes: ByteArray) = encodeIdentity(bytes)

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/ScaleEncoder.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encoder/ScaleEncoder.kt
@@ -5,6 +5,8 @@ import java.math.BigInteger
 
 interface ScaleEncoder : Encoder {
 
+    fun encodeRaw(value: Any?)
+
     fun encodeNumber(number: BigInteger)
 
     fun encodeByteArray(bytes: ByteArray)

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/serializers/RawScaleValue.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/serializers/RawScaleValue.kt
@@ -1,0 +1,35 @@
+package io.novasama.substrate_sdk_android.koltinx_serialization_scale.serializers
+
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.decoder.ScaleDecoder
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.encoder.ScaleEncoder
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+typealias RawScaleValue = @Serializable(with = RawScaleSerializer::class) Any?
+
+@JvmInline
+@Serializable
+value class AsRawScaleValue(val value: RawScaleValue)
+
+class RawScaleSerializer : KSerializer<Any?> {
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ScaleRawValue", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Any?
+    ) {
+        require(encoder is ScaleEncoder)
+        encoder.encodeRaw(value)
+    }
+
+    override fun deserialize(decoder: Decoder): Any? {
+        require(decoder is ScaleDecoder)
+        return decoder.decodeRaw()
+    }
+}

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/utils/Enums.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/utils/Enums.kt
@@ -1,8 +1,0 @@
-package io.novasama.substrate_sdk_android.koltinx_serialization_scale.utils
-
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.StructureKind
-
-fun SerialDescriptor.shouldUseTransientStructInEnum(): Boolean {
-    return kind is StructureKind.CLASS && elementsCount == 1
-}

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/CollectionEnumTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/CollectionEnumTest.kt
@@ -1,6 +1,7 @@
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
 
 import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.SerializedFallback
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -49,4 +50,28 @@ class CollectionEnumTest : DecodeTest() {
         raw = "a",
         expected = TestEnum2.A
     )
+
+    @Test
+    fun `should decode collection enum from dict entry with null value`() {
+        runDecodeTest(
+            expected = TestEnum.A,
+            raw = DictEnum.Entry("A", null)
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when attempting to decode from dict enum with non null value`() {
+        runDecodeTest(
+            expected = TestEnum.A,
+            raw = DictEnum.Entry("A", 1)
+        )
+    }
+
+    @Test
+    fun `should respect custom names for dict entry decoding`() {
+        runDecodeTest(
+            expected = TestEnum2.A,
+            raw = DictEnum.Entry("a", null)
+        )
+    }
 }

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/CollectionEnumTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/CollectionEnumTest.kt
@@ -1,6 +1,8 @@
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
 
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.Scale
 import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.SerializedFallback
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
 import kotlinx.serialization.SerialName
@@ -20,6 +22,18 @@ class CollectionEnumTest : DecodeTest() {
     enum class TestEnum2 {
         @SerialName("a") A, B, C
     }
+
+    @Serializable
+    enum class TestEnumNoFallback {
+        A, B
+    }
+
+    @SerializedFallback("F")
+    @Serializable
+    enum class EnumWithWrongFallback {
+        A, B, C
+    }
+
 
     @Test
     fun `should decode collection enum`() = runDecodeTest(
@@ -44,6 +58,17 @@ class CollectionEnumTest : DecodeTest() {
         raw = "D",
         expected = TestEnum.A
     )
+
+
+    @Test(expected = IllegalStateException::class)
+    fun `should throw when cannot resolve fallback`() {
+        Scale.decode<EnumWithWrongFallback>("D")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `should throw when faced unknown value without fallback`() {
+        Scale.decode<TestEnumNoFallback>("D")
+    }
 
     @Test
     fun `SerialName works`() = runDecodeTest(

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/RawTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/RawTest.kt
@@ -1,0 +1,26 @@
+package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
+
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.serializers.AsRawScaleValue
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.serializers.RawScaleValue
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import kotlinx.serialization.Serializable
+import org.junit.Test
+
+class RawTest : DecodeTest() {
+
+    @JvmInline
+    @Serializable
+    value class WithRaw(val raw: RawScaleValue)
+
+    @Test
+    fun `should decode raw value in property`() = runDecodeTest(
+        expected = WithRaw(raw = DictEnum.Entry("test", 1)),
+        raw = DictEnum.Entry("test", 1)
+    )
+
+    @Test
+    fun `should decode raw value top level`() = runDecodeTest(
+        expected = AsRawScaleValue(DictEnum.Entry("test", 1)),
+        raw = DictEnum.Entry("test", 1)
+    )
+}

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/CollectionEnumTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/CollectionEnumTest.kt
@@ -1,5 +1,9 @@
 package io.novasama.substrate_sdk_android.koltinx_serialization_scale.encode
 
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.AsDictEnum
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode.CollectionEnumTest
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode.CollectionEnumTest.TestEnum2
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -36,4 +40,26 @@ class CollectionEnumTest : EncodeTest() {
         value = TestEnum.C,
         expected = "c"
     )
+
+    @Serializable
+    @AsDictEnum
+    enum class TestEnumDict {
+        A, B, @SerialName("c") C
+    }
+
+    @Test
+    fun `should encode collection enum to dict entry with null value`() {
+        runEncodeTest(
+            expected = DictEnum.Entry("A", null),
+            value = TestEnumDict.A
+        )
+    }
+
+    @Test
+    fun `should respect custom names for dict entry encoding`() {
+        runEncodeTest(
+            expected = DictEnum.Entry("c", null),
+            value = TestEnumDict.C
+        )
+    }
 }

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/RawTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/RawTest.kt
@@ -1,0 +1,26 @@
+package io.novasama.substrate_sdk_android.koltinx_serialization_scale.encode
+
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.serializers.AsRawScaleValue
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.serializers.RawScaleValue
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import kotlinx.serialization.Serializable
+import org.junit.Test
+
+class RawTest : EncodeTest() {
+
+    @Serializable
+    @JvmInline
+    value class WithRaw(val raw: RawScaleValue)
+
+    @Test
+    fun `should encode raw value in property`() = runEncodeTest(
+        expected = DictEnum.Entry("test", 1),
+        value = WithRaw(DictEnum.Entry("test", 1))
+    )
+
+    @Test
+    fun `should decode raw value top level`() = runEncodeTest(
+        expected = DictEnum.Entry("test", 1),
+        value = AsRawScaleValue(DictEnum.Entry("test", 1))
+    )
+}


### PR DESCRIPTION
* Support for raw scale serialization
* Support for encoding regular enums to DictEnum.Entry with null associated value
* Improve error messages for enum decoding

### Changes

#### Raw scale serialization

* Useful when we want to operate low level scale structures for some of the fields / arguments
* `RawScaleValue` can be used for fields
* `AsRawScaleValue` wrapper can be used for top-level serialization (e.g. storage keys / whole values)

#### Regular enum encoding to DictEnum.Entry with null associated value

* Introduced`AsDictEnum` annotation that can be applied to `enum class` to signal that it should be encoded as `DictEnum.Entry`
