### PR TITLE
Fix/annotation search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '2.11.1'
+        versionName = '2.11.2'
         versionCode = 1
 
         // SDK and tools

--- a/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/utils/Annotations.kt
+++ b/koltinx-serialization-scale/src/main/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/utils/Annotations.kt
@@ -9,7 +9,7 @@ inline fun <reified T : Annotation> List<Annotation>.findAnnotation(): T? {
     return find { it is T } as? T
 }
 
-inline fun <reified T> SerialDescriptor.findAnnotation(): T? {
+inline fun <reified T : Annotation> SerialDescriptor.findAnnotation(): T? {
     return annotations.findAnnotation()
 }
 

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/MixedEncoderTypesTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/decode/MixedEncoderTypesTest.kt
@@ -1,0 +1,35 @@
+package io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
+
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.Scale
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.AsTuple
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.BinaryScale
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.annotations.EnumIndex
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.decodeFromByteArray
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MixedEncoderTypesTest {
+
+    @Serializable
+    sealed interface SealedWithMixedAnnotations {
+
+        @Serializable
+        @AsTuple
+        @EnumIndex(0)
+        data class A(val a: Boolean): SealedWithMixedAnnotations
+    }
+
+    @Test
+    fun `should decode struct in both formats`(){
+        val fromBinary = BinaryScale.decodeFromByteArray<SealedWithMixedAnnotations>( byteArrayOf(0x00, 0x01))
+        val fromRuntime = Scale.decode<SealedWithMixedAnnotations>(DictEnum.Entry("A", listOf(true)))
+
+        val expected = SealedWithMixedAnnotations.A(true)
+
+        assertEquals(fromRuntime, expected)
+        assertEquals(fromBinary, expected)
+    }
+}

--- a/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/MixedEncoderTypesTest.kt
+++ b/koltinx-serialization-scale/src/test/java/io/novasama/substrate_sdk_android/koltinx_serialization_scale/encode/MixedEncoderTypesTest.kt
@@ -1,0 +1,40 @@
+package io.novasama.substrate_sdk_android.koltinx_serialization_scale.encode
+
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.Scale
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.annotations.AsTuple
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.BinaryScale
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.annotations.EnumIndex
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.decodeFromByteArray
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.binary.encodeToByteArray
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.decode
+import io.novasama.substrate_sdk_android.koltinx_serialization_scale.encode
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MixedEncoderTypesTest {
+
+    @Serializable
+    sealed interface SealedWithMixedAnnotations {
+
+        @Serializable
+        @AsTuple
+        @EnumIndex(0)
+        data class A(val a: Boolean): SealedWithMixedAnnotations
+    }
+
+    @Test
+    fun `should encode struct in both formats`(){
+        val input = SealedWithMixedAnnotations.A(true)
+        val expectedBinary = byteArrayOf(0x00, 0x01)
+        val expectedRuntime = DictEnum.Entry("A", listOf(true))
+
+        val actualBinary = BinaryScale.encodeToByteArray<SealedWithMixedAnnotations>(input)
+        val actualRuntime = Scale.encode<SealedWithMixedAnnotations>(input)
+
+        assertArrayEquals(expectedBinary, actualBinary)
+        assertEquals(expectedRuntime, actualRuntime)
+    }
+}


### PR DESCRIPTION
Fix - findAnnotation finds wrong annotation because of wrong type bounds

Explanation by compiler:
<img width="951" height="253" alt="image" src="https://github.com/user-attachments/assets/8a3766f8-a44d-4cd8-97d2-3796f0b157cc" />
