### PR TITLE
Fix v4 inherited implication encoding 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '2.11.7'
+        versionName = '2.11.8'
         versionCode = 1
 
         // SDK and tools

--- a/substrate-sdk-android/src/main/java/io/novasama/substrate_sdk_android/runtime/extrinsic/builder/TransactionExtensionPipelineV4.kt
+++ b/substrate-sdk-android/src/main/java/io/novasama/substrate_sdk_android/runtime/extrinsic/builder/TransactionExtensionPipelineV4.kt
@@ -14,6 +14,11 @@ import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtensi
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.extensions.verifySignature.VerifySignature
 import io.novasama.substrate_sdk_android.runtime.metadata.TransactionExtensionMetadata
 
+// Version of the transaction extension pipeline used for the base implication. Legacy V4-signed
+// extrinsics are validated by the runtime through the new TransactionExtension pipeline with
+// `TxBaseImplication((EXTENSION_V0_VERSION, call))`, so embedded extensions observe this leading byte.
+private const val EXTENSION_V0_VERSION: Byte = 0
+
 class TransactionExtensionPipelineV4(
     private val runtime: RuntimeSnapshot,
 ) : TransactionBuildingPipeline {
@@ -63,6 +68,7 @@ class TransactionExtensionPipelineV4(
         override val extrinsicVersion: ExtrinsicVersion = ExtrinsicVersion.V4
 
         override fun ScaleCodecWriter.encodeImplication() {
+            writeByte(EXTENSION_V0_VERSION)
             encodeCall()
             encodeExtensions()
         }

--- a/substrate-sdk-android/src/main/java/io/novasama/substrate_sdk_android/runtime/extrinsic/v5/transactionExtension/InheritedImplicationExt.kt
+++ b/substrate-sdk-android/src/main/java/io/novasama/substrate_sdk_android/runtime/extrinsic/v5/transactionExtension/InheritedImplicationExt.kt
@@ -30,16 +30,21 @@ private const val PAYLOAD_HASH_THRESHOLD = 256
  * Convert given [InheritedImplication] to the payload [VerifySignature] expects to be signed by the user
  */
 fun InheritedImplication.signingPayload(): ByteArray {
-    val encoded = encoded()
-
     return when (extrinsicVersion) {
-        is ExtrinsicVersion.V4 -> if (encoded.size > PAYLOAD_HASH_THRESHOLD) {
-            encoded.blake2b256()
-        } else {
-            encoded
+        // Legacy V4-signed extrinsics use the envelope SignedPayload `(call, extra, implicit)`, which is
+        // version-byte-free. V4 `encoded()` now carries the TxBaseImplication version byte for embedded
+        // extensions, so build the envelope payload explicitly from call + extensions to exclude it.
+        is ExtrinsicVersion.V4 -> {
+            val encoded = encodedCall() + encodedExtensions()
+
+            if (encoded.size > PAYLOAD_HASH_THRESHOLD) {
+                encoded.blake2b256()
+            } else {
+                encoded
+            }
         }
 
-        is ExtrinsicVersion.V5 -> encoded.blake2b256()
+        is ExtrinsicVersion.V5 -> encoded().blake2b256()
     }
 }
 


### PR DESCRIPTION
Previously, V4 inherited implication was encoded without any extrinsic version byte to mirror how v4 SigningPayload is constructed. However runtime actually prepends zero byte for InheritedImplication encoding and its only `SigningPayload` that does that differently